### PR TITLE
add in structured logs for easier parsing

### DIFF
--- a/lib/plugins/s3HtmlCache.js
+++ b/lib/plugins/s3HtmlCache.js
@@ -32,12 +32,12 @@ module.exports = {
 
         this.cache.get(req.prerender.url, function (err, result) {
             if (!err && result) {
-                util.log('state=CACHE_HIT url="' + req.prerender.url + '"');
+                util.log('action=cache.resolve state=CACHE_HIT url="' + req.prerender.url + '"');
                 return res.send(200, result.Body);
             } else {
-                util.log('state=CACHE_MISS url="' + req.prerender.url + '"');
+                util.log('action=cache.resolve state=CACHE_MISS url="' + req.prerender.url + '"');
             }
-            
+
             next();
         });
     },
@@ -51,7 +51,7 @@ module.exports = {
             if (err) console.error(err);
             next();
         });
-        
+
     }
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -122,7 +122,7 @@ server.onRequest = function(req, res) {
         start: new Date()
     };
 
-    util.log('getting', req.prerender.url);
+    util.log('action=request.started url=', req.prerender.url);
 
     this._pluginEvent("beforePhantomRequest", [req, res], function() {
         _this.createPage(req, res);
@@ -582,7 +582,7 @@ server._sendResponse = function(req, res, options) {
     }
 
     var ms = new Date().getTime() - req.prerender.start.getTime();
-    util.log('got', req.prerender.statusCode, 'in', ms + 'ms', 'for', req.prerender.url);
+    util.log('action=request.finished url=', req.prerender.url, ' status=', req.prerender.statusCode, ' duration=', ms)
 
     if(this.shouldKillPhantomJS(req) || (options && options.abort)) {
         req.prerender.isPageClosed = true;


### PR DESCRIPTION
I was looking for timings in scalyr, the current format was not easily searchable. This should make it easier.

```
2017-10-17T00:00:07.296Z getting https://www.netlify.com/status/6e65ea5a-897b-47f7-9b6f-ddc03683b683
2017-10-17T00:00:07.339Z state=CACHE_HIT url="https://www.netlify.com/status/6e65ea5a-897b-47f7-9b6f-ddc03683b683"
2017-10-17T00:00:07.339Z got 200 in 43ms for https://www.netlify.com/status/6e65ea5a-897b-47f7-9b6f-ddc03683b683
```

That is the previous log style. I don't know the code well enough to introduce a request id, but it could be another thing we add.