### PR TITLE
Don't decode prerender url unnecessarily

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -54,8 +54,7 @@ util.getOptions = function(req) {
 
 // Gets the URL to prerender from a request, stripping out unnecessary parts
 util.getUrl = function(requestedUrl) {
-	var decodedUrl, realUrl = requestedUrl,
-		parts;
+	var realUrl = requestedUrl, parts;
 
 	if (!requestedUrl) {
 		return '';
@@ -63,12 +62,11 @@ util.getUrl = function(requestedUrl) {
 
 	realUrl = realUrl.replace(/^\//, '');
 
-	try {
-		parts = url.parse(realUrl, true);
-	} catch (err) {
-		// maybe the entire url has been encoded so try decoding first
-		parts = url.parse(decodeURIComponent(realUrl), true);
+	// check if the entire url has been encoded and decode it first
+	if (realUrl.startsWith("http%3A%2F%2F") || realUrl.startsWith("https%3A%2F%2F")) {
+		realUrl = decodeURIComponent(realUrl);
 	}
+	parts = url.parse(realUrl, true);
 
 	// Remove the _escaped_fragment_ query parameter
 	if (parts.query && parts.query['_escaped_fragment_'] !== undefined) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -54,19 +54,17 @@ util.getOptions = function(req) {
 
 // Gets the URL to prerender from a request, stripping out unnecessary parts
 util.getUrl = function(requestedUrl) {
-	var realUrl = requestedUrl, parts;
-
 	if (!requestedUrl) {
 		return '';
 	}
 
-	realUrl = realUrl.replace(/^\//, '');
+	var realUrl = requestedUrl.replace(/^\//, '');
 
 	// check if the entire url has been encoded and decode it first
 	if (realUrl.startsWith("http%3A%2F%2F") || realUrl.startsWith("https%3A%2F%2F")) {
 		realUrl = decodeURIComponent(realUrl);
 	}
-	parts = url.parse(realUrl, true);
+	var parts = url.parse(realUrl, true);
 
 	// Remove the _escaped_fragment_ query parameter
 	if (parts.query && parts.query['_escaped_fragment_'] !== undefined) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,27 +64,23 @@ util.getUrl = function(requestedUrl) {
 	realUrl = realUrl.replace(/^\//, '');
 
 	try {
-		decodedUrl = decodeURIComponent(realUrl);
-	} catch (e) {
-		decodedUrl = realUrl;
+		parts = url.parse(realUrl, true);
+	} catch (err) {
+		// maybe the entire url has been encoded so try decoding first
+		parts = url.parse(decodeURIComponent(realUrl), true);
 	}
-
-	//encode a # for a non #! URL so that we access it correctly
-	decodedUrl = this.encodeHash(decodedUrl);
-
-	//if decoded url has two query params from a decoded escaped fragment for hashbang URLs
-	if (decodedUrl.indexOf('?') !== decodedUrl.lastIndexOf('?')) {
-		decodedUrl = decodedUrl.substr(0, decodedUrl.lastIndexOf('?')) + '&' + decodedUrl.substr(decodedUrl.lastIndexOf('?') + 1);
-	}
-
-	parts = url.parse(decodedUrl, true);
 
 	// Remove the _escaped_fragment_ query parameter
 	if (parts.query && parts.query['_escaped_fragment_'] !== undefined) {
+		const fragment = url.parse(decodeURIComponent(parts.query['_escaped_fragment_']), true);
 
-		if (parts.query['_escaped_fragment_'] && !Array.isArray(parts.query['_escaped_fragment_'])) {
-			parts.hash = '#!' + parts.query['_escaped_fragment_'];
+		if (fragment.pathname) {
+			parts.hash = '#!' + fragment.pathname;
 		}
+
+		// If _escaped_fragment_ had a query embedded in it with a ?, merge it with the
+		// url params here.
+		parts.query = { ...parts.query, ...fragment.query };
 
 		delete parts.query['_escaped_fragment_'];
 		delete parts.search;
@@ -93,16 +89,7 @@ util.getUrl = function(requestedUrl) {
 	// Bing was seen accessing a URL like /?&_escaped_fragment_=
 	delete parts.query[''];
 
-	var newUrl = url.format(parts);
-
-	//url.format encodes spaces but not arabic characters. decode it here so we can encode it all correctly later
-	try {
-		newUrl = decodeURIComponent(newUrl);
-	} catch (e) {}
-
-	newUrl = this.encodeHash(newUrl);
-
-	return newUrl;
+	return url.format(parts);
 };
 
 util.encodeHash = function(url) {

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -103,6 +103,14 @@ describe('Prerender', function() {
 			assert.equal(url, 'http://www.example.com/?brand=h%26m&size=m');
 		});
 
+		it('should handle fully encoded urls', function() {
+			var url = util.getUrl(encodeURIComponent('http://www.example.com/?brand=h%26m&size=m'));
+			assert.equal(url, 'http://www.example.com/?brand=h%26m&size=m');
+
+			url = util.getUrl(encodeURIComponent('https://www.example.com/?brand=h%26m&size=m'));
+			assert.equal(url, 'https://www.example.com/?brand=h%26m&size=m');
+		});
+
 		it('should handle params before and after #!', function() {
 			var url = util.getUrl('www.example.com?user=userid&_escaped_fragment_=key1=value1%26key2=value2');
 			assert.equal(url, 'www.example.com?user=userid#!key1=value1&key2=value2');

--- a/test/index-spec.js
+++ b/test/index-spec.js
@@ -96,5 +96,17 @@ describe('Prerender', function() {
 
 			assert.equal(url, 'http://www.example.com/كاليفورنيا');
 		});
+
+
+		it('should not decode url encoded characters', function() {
+			var url = util.getUrl('http://www.example.com/?brand=h%26m&size=m');
+			assert.equal(url, 'http://www.example.com/?brand=h%26m&size=m');
+		});
+
+		it('should handle params before and after #!', function() {
+			var url = util.getUrl('www.example.com?user=userid&_escaped_fragment_=key1=value1%26key2=value2');
+			assert.equal(url, 'www.example.com?user=userid#!key1=value1&key2=value2');
+		})
+
 	});
 });


### PR DESCRIPTION
This can break urls that only have certain characters encoded, e.g `http://example.com?brand=h&m`. With this change, we'll only try to decode the full url after parsing it fails. 

The `_escaped_fragment_` parameter is always decoded when it's present and parsed separately, which fixes a different issue. See the last test case in `index-spec.js`. This is an example from https://developers.google.com/search/docs/ajax-crawling/docs/specification, which the previous version was handling incorrectly.

There was another `decodeURIComponent` call right before the end of the function, which according to git history was introduced to fix an issue with PhantomJS, but the project has since moved on to Chrome so this doesn't appear to be an issue anymore.