### PR TITLE
Copy gracefulBrowserRestart from netlify/chrome-prerender

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -77,6 +77,7 @@ server.startPrerender = function() {
 			this.browserRequestsInFlight = 0;
 			this.lastRestart = new Date().getTime();
 			this.isBrowserConnected = true;
+			this.waitForInflightRequests = false;
 			util.log(`Started ${this.browser.name}: ${this.browser.version}`)
 			resolve();
 		}).catch((err) => {
@@ -112,7 +113,15 @@ server.restartBrowser = function() {
 	this.browser.kill();
 };
 
-
+server.gracefulBrowserRestart = function() {
+	this.isBrowserConnected = false;
+	util.log(`Graceful restarting ${this.browser.name}`);
+	if (this.browserRequestsInFlight <= 0) {
+		this.browser.kill();
+	} else {
+		this.waitForInflightRequests = true;
+	}
+};
 
 server.connectToBrowser = function() {
 	return this.browser.connect();
@@ -287,7 +296,7 @@ server.finish = function(req, res) {
 		this.browserRequestsInFlight--;
 	}
 
-	if (this.browserRequestsInFlight <= 0 && new Date().getTime() - this.lastRestart > BROWSER_TRY_RESTART_PERIOD) {
+	if (this.browserRequestsInFlight <= 0 && ((new Date().getTime() - this.lastRestart > BROWSER_TRY_RESTART_PERIOD) || this.waitForInflightRequests)) {
 		this.lastRestart = new Date().getTime();
 		this.restartBrowser();
 	}


### PR DESCRIPTION
Graceful restart currently isn't working because this function is missing (found by @jose-ledesma in github.com/netlify/chrome-prerender). See https://netlify.slack.com/archives/CQ65PCZ4J/p1625931368363700 for context.