### PR TITLE
feat: allow for simultaneous basic auth creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,17 +218,24 @@ You can enable the plugins in `server.js` by uncommenting the corresponding line
 
 If you want to only allow access to your Prerender server from authorized parties, enable the basic auth plugin.
 
-You will need to add the `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` environment variables.
+You will need to add the `BASIC_AUTH` environment variable. This is a CSV of username:password pairs:
 ```
-export BASIC_AUTH_USERNAME=prerender
-export BASIC_AUTH_PASSWORD=test
+export BASIC_AUTH=u1:p1,u1:p2,u2:p3
 ```
 
-Then make sure to pass the basic authentication headers (password base64 encoded).
+Then make sure to pass the basic authentication headers.
 
-```
+``` 
 curl -u prerender:wrong http://localhost:1337/http://example.com -> 401
-curl -u prerender:test http://localhost:1337/http://example.com -> 200
+curl -u u1:p2 http://localhost:1337/http://example.com -> 200
+
+
+# or if you want to explicitly set the header
+
+echo -n "u1:p2" | base64
+# dTE6cDI=
+
+curl -H "Authorization: Basic dTE6cDI=" http://localhost:1337/http://example.com
 ```
 
 ### removeScriptTags

--- a/lib/plugins/basicAuth.js
+++ b/lib/plugins/basicAuth.js
@@ -3,7 +3,7 @@
 // parse out into credential pairs:
 // 		[ [ 'a', 'b' ], [ 'c', 'd' ], [ 'e', 'f' ] ]
 if (!process.env.BASIC_AUTH) {
-	throw new Error("missing BASIC_AUTH env var")
+	throw new Error("missing BASIC_AUTH env var");
 }
 const CREDS = process.env.BASIC_AUTH.split(",").map((cred) =>  cred.split(":"));
 

--- a/lib/plugins/basicAuth.js
+++ b/lib/plugins/basicAuth.js
@@ -24,7 +24,7 @@ module.exports = {
 		auth = auth.match(/^([^:]+):(.+)$/);
 		if (!auth) return res.send(401);
 
-		let authenticated = CREDS.some((cred) =>  auth[1] === cred[0] && auth[2] === cred[1]);
+		const authenticated = CREDS.some((cred) =>  auth[1] === cred[0] && auth[2] === cred[1]);
 		if (!authenticated) {
 			return res.send(401);
 		}

--- a/lib/plugins/basicAuth.js
+++ b/lib/plugins/basicAuth.js
@@ -5,7 +5,7 @@
 if (!process.env.BASIC_AUTH) {
 	throw new Error("missing BASIC_AUTH env var")
 }
-const CREDS = process.env.BASIC_AUTH.split(",").map((cred) =>  cred.split(":") );
+const CREDS = process.env.BASIC_AUTH.split(",").map((cred) =>  cred.split(":"));
 
 
 module.exports = {

--- a/lib/plugins/basicAuth.js
+++ b/lib/plugins/basicAuth.js
@@ -1,3 +1,13 @@
+// env var is specified like:
+// 		BASIC_AUTH=a:b,c:d,e:f
+// parse out into credential pairs:
+// 		[ [ 'a', 'b' ], [ 'c', 'd' ], [ 'e', 'f' ] ]
+if (!process.env.BASIC_AUTH) {
+	throw new Error("missing BASIC_AUTH env var")
+}
+const CREDS = process.env.BASIC_AUTH.split(",").map((cred) =>  cred.split(":") );
+
+
 module.exports = {
 	requestReceived: (req, res, next) => {
 		let auth = req.headers.authorization;
@@ -14,7 +24,10 @@ module.exports = {
 		auth = auth.match(/^([^:]+):(.+)$/);
 		if (!auth) return res.send(401);
 
-		if (auth[1] !== process.env.BASIC_AUTH_USERNAME || auth[2] !== process.env.BASIC_AUTH_PASSWORD) return res.send(401);
+		let authenticated = CREDS.some((cred) =>  auth[1] === cred[0] && auth[2] === cred[1] )
+		if (!authenticated) {
+			return res.send(401);
+		}
 
 		req.prerender.authentication = {
 			name: auth[1],

--- a/lib/plugins/basicAuth.js
+++ b/lib/plugins/basicAuth.js
@@ -24,7 +24,7 @@ module.exports = {
 		auth = auth.match(/^([^:]+):(.+)$/);
 		if (!auth) return res.send(401);
 
-		let authenticated = CREDS.some((cred) =>  auth[1] === cred[0] && auth[2] === cred[1] )
+		let authenticated = CREDS.some((cred) =>  auth[1] === cred[0] && auth[2] === cred[1]);
 		if (!authenticated) {
 			return res.send(401);
 		}

--- a/lib/plugins/healthCheckAuth.js
+++ b/lib/plugins/healthCheckAuth.js
@@ -1,11 +1,11 @@
 // This is copied from basicAuth.js
 if (!process.env.BASIC_AUTH) {
-  throw new Error("missing BASIC_AUTH env var")
+  throw new Error("missing BASIC_AUTH env var");
 }
 const CREDS = process.env.BASIC_AUTH.split(",").map((cred) =>  cred.split(":"));
 
 if (CREDS.length < 1 && CREDS[0].length !== 2) {
-  throw new Error("BASIC_AUTH must specify at least one credential pair")
+  throw new Error("BASIC_AUTH must specify at least one credential pair");
 }
 
 module.exports = {

--- a/lib/plugins/healthCheckAuth.js
+++ b/lib/plugins/healthCheckAuth.js
@@ -1,8 +1,18 @@
+// This is copied from basicAuth.js
+if (!process.env.BASIC_AUTH) {
+  throw new Error("missing BASIC_AUTH env var")
+}
+const CREDS = process.env.BASIC_AUTH.split(",").map((cred) =>  cred.split(":") );
+
+if (CREDS.length < 1 && CREDS[0].length !== 2) {
+  throw new Error("BASIC_AUTH must specify at least one credential pair")
+}
+
 module.exports = {
   requestReceived(req, res, next) {
     if (req.prerender.url == process.env.STATUS_URL) {
-      const username = process.env.BASIC_AUTH_USERNAME;
-      const password = process.env.BASIC_AUTH_PASSWORD;
+      const username = CREDS[0][0];
+      const password = CREDS[0][1];
       const buf = new Buffer(username + ":" + password).toString("base64");
       req.headers.authorization = `Basic ${buf}`;
     }

--- a/lib/plugins/healthCheckAuth.js
+++ b/lib/plugins/healthCheckAuth.js
@@ -2,7 +2,7 @@
 if (!process.env.BASIC_AUTH) {
   throw new Error("missing BASIC_AUTH env var")
 }
-const CREDS = process.env.BASIC_AUTH.split(",").map((cred) =>  cred.split(":") );
+const CREDS = process.env.BASIC_AUTH.split(",").map((cred) =>  cred.split(":"));
 
 if (CREDS.length < 1 && CREDS[0].length !== 2) {
   throw new Error("BASIC_AUTH must specify at least one credential pair")

--- a/lib/plugins/healthCheckAuth.js
+++ b/lib/plugins/healthCheckAuth.js
@@ -4,7 +4,7 @@ if (!process.env.BASIC_AUTH) {
 }
 const CREDS = process.env.BASIC_AUTH.split(",").map((cred) =>  cred.split(":"));
 
-if (CREDS.length < 1 && CREDS[0].length !== 2) {
+if (CREDS.length < 1 || CREDS[0].length !== 2) {
   throw new Error("BASIC_AUTH must specify at least one credential pair");
 }
 


### PR DESCRIPTION
Part of https://github.com/netlify/pillar-runtime/issues/538.

In order to rotate the creds, we need prerender to support multiple valid creds at one time. That way we can phase out the usage of the old creds in all the systems that call prerender. 